### PR TITLE
[planner_cspace_msgs] Depend on action_msgs instead of actionlib_msgs

### DIFF
--- a/planner_cspace_msgs/package.xml
+++ b/planner_cspace_msgs/package.xml
@@ -16,7 +16,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <depend>actionlib_msgs</depend>
+  <depend>action_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
 


### PR DESCRIPTION
## 概要

`planner_cspace_msgs` の `MoveWithTolerance.action` が ROS 2 でビルドできず、CMake エラー `Unable to generate action interface ... you must add a depend tag for 'action_msgs'` で失敗していた。

`actionlib_msgs` は ROS 1 の action メタパッケージで ROS 2 には存在しない。`MoveWithTolerance.action` は `geometry_msgs` しか参照していないため、ROS 1 依存の `actionlib_msgs` を ROS 2 の rosidl action 生成に必要な `action_msgs` に置き換える。

## 動作確認

- [x] `neonavigation_msgs` の humble ブランチ全 8 パッケージを ROS 2 Humble コンテナで `colcon build` → 全て成功（本修正なしでは `planner_cspace_msgs` が上記エラーで失敗）。

## 背景

smilerobotics/neonavigation の CI を ROS 2 Humble (industrial_ci) に移行する PR で、upstream ワークスペースとしてこのリポジトリを `@humble` からビルドしたところ `planner_cspace_msgs` がこのエラーで落ちていた（他パッケージは巻き添えで abort されていただけ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)